### PR TITLE
Fix plain API key statement

### DIFF
--- a/Interfaces/Mailer.cs
+++ b/Interfaces/Mailer.cs
@@ -14,8 +14,7 @@ namespace JakupovicNL
 
 		public Mailer()
 		{
-			//_apiKey = Environment.GetEnvironmentVariable(Startup._sendgridApiKey);
-			_apiKey = "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";
+			_apiKey = Environment.GetEnvironmentVariable(Startup._sendgridApiKey);
             _client = new SendGridClient(_apiKey);
 		}
 

--- a/Interfaces/Mailer.cs
+++ b/Interfaces/Mailer.cs
@@ -15,18 +15,18 @@ namespace JakupovicNL
 		public Mailer()
 		{
 			_apiKey = Environment.GetEnvironmentVariable(Startup._sendgridApiKey);
-            _client = new SendGridClient(_apiKey);
+			_client = new SendGridClient(_apiKey);
 		}
 
 		public async Task<Response> SendEmail(EmailForm form)
 		{
 			var from = new EmailAddress(form.EmailAddress, form.Name);
-            var subject = "Someone send you a message!";
-            var to = new EmailAddress("jakupovicdennis@gmail.com", "Nuss");
-            var plainTextContent = form.Message;
-            var htmlContent = $"<strong>{form.Message}</strong>";
-            var msg = MailHelper.CreateSingleEmail(from, to, subject, plainTextContent, htmlContent);
-            var response =  await _client.SendEmailAsync(msg);
+			var subject = "Someone send you a message!";
+			var to = new EmailAddress("jakupovicdennis@gmail.com", "Nuss");
+			var plainTextContent = form.Message;
+			var htmlContent = $"<strong>{form.Message}</strong>";
+			var msg = MailHelper.CreateSingleEmail(from, to, subject, plainTextContent, htmlContent);
+			var response =  await _client.SendEmailAsync(msg);
 
 			return response;
 		}


### PR DESCRIPTION
During testing used the plain API key to exclude secret manager from the flow. Unfortunately forgot to remove this line during push.
Hereby removed the line of code, and also deleted the API key from the SendGrid account.